### PR TITLE
Optimisation du server et client, généralisation de la consommation des ressources

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -23,9 +23,10 @@ function App() {
 
             //parse data to Simulation
             //json beautifier print
-            console.log(data);
+            //console.log(data);
 
             let simulation = new Simulation(data);
+            console.log(simulation)
             setSimulation(simulation);
         }
 

--- a/client/src/Entity.tsx
+++ b/client/src/Entity.tsx
@@ -53,14 +53,14 @@ class MarketBuyEvent implements EventType{
 
 // Implement the TransferResourceEvent class
 class TransferResourceEvent implements EventType{
-    from: Territory;
-    to: Territory;
+    from: string;
+    to: string;
     resource: string;
     amount: number;
 
     constructor(data: any, country?: Country) {
-        this.from = new Territory(data.from, country);
-        this.to = new Territory(data.to, country);
+        this.from = data.from;
+        this.to = data.to;
         this.resource = data.resource;
         this.amount = data.amount;
     }
@@ -106,7 +106,6 @@ class Country {
     color: string;
     money: number;
     history: CountryEvent[];
-    territories: Territory[];
     moneyHistory: Map<string, number>;
 
     constructor(data: any) {
@@ -114,7 +113,6 @@ class Country {
         this.color = data.color;
         this.money = data.money;
         this.history = data.history.map((eventData: any) => new CountryEvent(eventData, this));
-        this.territories = data.territories.map((territoryData: any) => new Territory(territoryData, this));
         this.moneyHistory = new Map<string, number>(Object.entries(data.moneyHistory));
     }
 }
@@ -122,6 +120,7 @@ class Country {
 class Territory {
     x: number;
     y: number;
+    name: string;
     variations: Variation[];
     stock: Map<string, number>;
     stockHistory: Map<number, Map<string, number>>;
@@ -129,13 +128,14 @@ class Territory {
     habitantsHistory: Map<string, number>;
     country: Country | undefined;
 
-    constructor(data: any, country?: Country) {
+    constructor(data: any) {
         this.x = data.x;
         this.y = data.y;
+        this.name = data.name;
         this.variations = data.variations.map((variationData: any) => new Variation(variationData));
         this.stock = new Map<string, number>(Object.entries(data.stock));
         this.habitants = data.habitants;
-        this.country = country;
+        this.country = new Country(data.country);
         this.stockHistory = new Map<number, Map<string, number>>();
         for (const key in data.stockHistory) {
             const innerMap = new Map<string, number>(Object.entries(data.stockHistory[key]));
@@ -150,16 +150,16 @@ class MarketInteraction {
     resourceType: string;
     amount: number;
     price: number;
-    buyer: Country ;
-    seller: Country;
+    buyer: string ;
+    seller: string;
 
     constructor(data: any) {
         this.dateTransaction = data.dateTransaction;
         this.resourceType = data.resourceType;
         this.amount = data.amount;
         this.price = data.price;
-        this.buyer = new Country(data.buyer);
-        this.seller = new Country(data.seller);
+        this.buyer = data.buyer.agent.name;
+        this.seller = data.seller.agent.name;
     }
 }
 
@@ -175,9 +175,11 @@ class Market {
 
 class Environment {
     market : Market;
+    consumptionByHabitant: Map<string, number>;
 
     constructor(data: any) {
         this.market = new Market(data.market);
+        this.consumptionByHabitant = new Map<string, number>(Object.entries(data.consumptionByHabitant))
     }
 }
 
@@ -199,15 +201,6 @@ class Simulation {
                 new Country(countryData),
             ])
         );
-        for (let territory of this.territories) {
-            for (let country of this.countries.values()) {
-                for (let countryTerritory of country.territories) {
-                    if (territory.x === countryTerritory.x && territory.y === countryTerritory.y) {
-                        territory.country = country;
-                    }
-                }
-            }
-        }
         this.currentDay = data.currentDay;
     }
 }

--- a/server/gopolitical/simulation.go
+++ b/server/gopolitical/simulation.go
@@ -17,19 +17,15 @@ type Simulation struct {
 	WebSocket   *WebSocket `json:"-"`
 }
 
-const (
-	WATER_BY_HABITANT = 0.5
-	FOOD_BY_HABITANT  = 0.5
-)
-
 func NewSimulation(
 	secondByDay float64,
 	prices Prices,
 	countries map[string]*Country,
 	territories []*Territory,
 	wg *sync.WaitGroup,
+	consumptionsByHabitant map[ResourceType]float64,
 ) Simulation {
-	return Simulation{secondByDay, NewEnvironment(countries, territories, prices, wg), territories, countries, 0, wg, nil}
+	return Simulation{secondByDay, NewEnvironment(countries, territories, prices, wg, consumptionsByHabitant), territories, countries, 0, wg, nil}
 }
 
 func (s *Simulation) Start() {

--- a/server/gopolitical/territory.go
+++ b/server/gopolitical/territory.go
@@ -3,16 +3,17 @@ package gopolitical
 type Territory struct {
 	X                int                              `json:"x"`
 	Y                int                              `json:"y"`
+	Name             string                           `json:"name"`
 	Variations       []Variation                      `json:"variations"`
 	Stock            map[ResourceType]float64         `json:"stock"`
 	StockHistory     map[int]map[ResourceType]float64 `json:"stockHistory"`
-	Country          *Country                         `json:"-"`
+	Country          *Country                         `json:"country"`
 	Habitants        int                              `json:"habitants"`
 	HabitantsHistory map[int]int                      `json:"habitantsHistory"`
 }
 
-func NewTerritory(x int, y int, variations []Variation, stock map[ResourceType]float64, country *Country, habitant int) *Territory {
-	return &Territory{x, y, variations, stock, make(map[int]map[ResourceType]float64), country, habitant, make(map[int]int)}
+func NewTerritory(x int, y int, name string, variations []Variation, stock map[ResourceType]float64, country *Country, habitant int) *Territory {
+	return &Territory{x, y, name, variations, stock, make(map[int]map[ResourceType]float64), country, habitant, make(map[int]int)}
 }
 
 func (t Territory) Start() {
@@ -32,17 +33,14 @@ func (t Territory) Act() {
 }
 
 func (t *Territory) GetSurplus(daysToSecure float64) map[ResourceType]float64 {
-	//TODO: Rendre générique pour toutes les ressources
 	surplus := make(map[ResourceType]float64)
 	//On garde 3 jours de surplus
-	surplusFood := t.Stock["food"] - (float64(t.Habitants)*FOOD_BY_HABITANT)*daysToSecure
-	surplusWater := t.Stock["water"] - (float64(t.Habitants)*WATER_BY_HABITANT)*daysToSecure
 
-	if surplusFood > 0 {
-		surplus["food"] = surplusFood
-	}
-	if surplusWater > 0 {
-		surplus["water"] = surplusWater
+	for resource, consumption := range t.Country.consumptionByHabitant {
+		surplusAmount := t.Stock[resource] - (float64(t.Habitants)*consumption)*daysToSecure
+		if surplusAmount > 0 {
+			surplus[resource] = surplusAmount
+		}
 	}
 	return surplus
 }

--- a/server/resources/data.json
+++ b/server/resources/data.json
@@ -1,9 +1,9 @@
 {
-  "secondByDay": 5.0,
+  "secondByDay": 2.0,
   "resources": [
     {
       "name": "petrol",
-      "price": 30
+      "price": 10
     },
     {
       "name": "water",
@@ -18,18 +18,33 @@
       "price": 10
     }
   ],
+
+  "consumptionsByHabitant": [
+    {
+      "name": "petrol",
+      "value": 0.2
+    },
+    {
+      "name": "water",
+      "value": 0.5
+    },
+    {
+      "name": "food",
+      "value": 0.5
+    }
+  ],
   "countries": [
     {
       "name": "Russie",
       "id": "ru",
       "color": "FF0000",
-      "money": 100.0
+      "money": 150.0
     },
     {
       "name": "United-state",
       "id": "us",
       "color": "0000FF",
-      "money": 100.0
+      "money": 150.0
     }
   ],
   "relations": [
@@ -44,17 +59,26 @@
       "x": 0,
       "y": 0,
       "country": "ru",
+      "name": "territory_1",
       "habitants": 15,
       "stocks": [
         {
           "name": "armement",
           "value": 10
+        },
+        {
+          "name": "petrol",
+          "value": 10
+        },
+        {
+          "name": "water",
+          "value": 5
         }
       ],
       "variations": [
         {
           "name": "petrol",
-          "value": 10
+          "value": 2
         },
         {
           "name": "water",
@@ -66,11 +90,26 @@
       "x": 0,
       "y": 1,
       "country": "ru",
+      "name": "territory_2",
       "habitants": 10,
+      "stocks": [
+        {
+          "name": "armement",
+          "value": 10
+        },
+        {
+          "name": "petrol",
+          "value": 9
+        },
+        {
+          "name": "water",
+          "value": 5
+        }
+      ],
       "variations": [
         {
           "name": "petrol",
-          "value": 10
+          "value": 3
         },
         {
           "name": "food",
@@ -86,11 +125,26 @@
       "x": 1,
       "y": 1,
       "country": "ru",
+        "name": "territory_3",
       "habitants": 10,
+      "stocks": [
+        {
+          "name": "armement",
+          "value": 10
+        },
+        {
+          "name": "petrol",
+          "value": 4
+        },
+        {
+          "name": "water",
+          "value": 5
+        }
+      ],
       "variations": [
         {
           "name": "petrol",
-          "value": 10
+          "value": 3
         },
         {
           "name": "water",
@@ -102,11 +156,26 @@
       "x": 1,
       "y": 0,
       "country": "us",
+      "name": "territory_4",
       "habitants": 20,
+      "stocks": [
+        {
+          "name": "armement",
+          "value": 10
+        },
+        {
+          "name": "petrol",
+          "value": 3
+        },
+        {
+          "name": "water",
+          "value": 5
+        }
+      ],
       "variations": [
         {
           "name": "petrol",
-          "value": 10
+          "value": 5
         },
         {
           "name": "food",
@@ -118,7 +187,22 @@
       "x": 2,
       "y": 0,
       "country": "us",
+      "name": "territory_5",
       "habitants": 10,
+      "stocks": [
+        {
+          "name": "armement",
+          "value": 10
+        },
+        {
+          "name": "petrol",
+          "value": 4
+        },
+        {
+          "name": "water",
+          "value": 5
+        }
+      ],
       "variations": [
         {
           "name": "food",
@@ -134,7 +218,22 @@
       "x": 2,
       "y": 1,
       "country": "us",
+      "name": "territory_6",
       "habitants": 10,
+      "stocks": [
+        {
+          "name": "armement",
+          "value": 10
+        },
+        {
+          "name": "petrol",
+          "value": 3
+        },
+        {
+          "name": "water",
+          "value": 5
+        }
+      ],
       "variations": [
         {
           "name": "food",
@@ -146,7 +245,22 @@
       "x": 2,
       "y": 2,
       "country": "us",
+        "name": "territory_7",
       "habitants": 10,
+      "stocks": [
+        {
+          "name": "armement",
+          "value": 10
+        },
+        {
+          "name": "petrol",
+          "value": 10
+        },
+        {
+          "name": "water",
+          "value": 5
+        }
+      ],
       "variations": [
         {
           "name": "food",
@@ -155,6 +269,10 @@
         {
           "name": "water",
           "value": 5
+        },
+        {
+          "name": "petrol",
+          "value": 5
         }
       ]
     },
@@ -162,7 +280,22 @@
       "x": 0,
       "y": 3,
       "country": "us",
+        "name": "territory_8",
       "habitants": 10,
+      "stocks": [
+        {
+          "name": "armement",
+          "value": 10
+        },
+        {
+          "name": "petrol",
+          "value": 10
+        },
+        {
+          "name": "water",
+          "value": 5
+        }
+      ],
       "variations": [
         {
           "name": "food",


### PR DESCRIPTION
[Server]
- Fusion si possible des MarketSellResponse et MarketBuyResponse => Moins d'éléments dans l'historique
- Ajout des consommations par habitants dans le json
- Rendre générique la consommation des ressources et la vente des ressources
- Un pays attend le traitement des requêtes par l'environnement avant de faire wg.Done 

[Client]
- Enlever la liste des territoires dans country
- Ajouter dans l'environnement la Map des consommations par habitants